### PR TITLE
Pep8 improvements

### DIFF
--- a/openbrokerapi/api.py
+++ b/openbrokerapi/api.py
@@ -6,9 +6,26 @@ from flask import Blueprint
 from flask import json, request, jsonify, Response
 
 from openbrokerapi import errors
-from openbrokerapi.response import *
-from openbrokerapi.service_broker import *
-from openbrokerapi.service_broker import ProvisionState
+from openbrokerapi.response import (
+    BindResponse,
+    CatalogResponse,
+    DeprovisionResponse,
+    EmptyResponse,
+    ErrorResponse,
+    LastOperationResponse,
+    ProvisioningResponse,
+    UpdateResponse,
+)
+from openbrokerapi.service_broker import (
+    BindDetails,
+    BindState,
+    DeprovisionDetails,
+    ProvisionDetails,
+    ProvisionState,
+    ServiceBroker,
+    UnbindDetails,
+    UpdateDetails,
+)
 
 
 class BrokerCredentials:

--- a/test/test_bind.py
+++ b/test/test_bind.py
@@ -19,7 +19,7 @@ class BindTest(BrokerTestCase):
             credentials=expected_credentials
         )
 
-        _ = self.client.put(
+        self.client.put(
             "/v2/service_instances/here-instance_id/service_bindings/here-binding_id",
             data=json.dumps({
                 "service_id": "service-guid-here",
@@ -55,7 +55,7 @@ class BindTest(BrokerTestCase):
             credentials=expected_credentials
         )
 
-        _ = self.client.put(
+        self.client.put(
             "/v2/service_instances/here-instance_id/service_bindings/here-binding_id",
             data=json.dumps({
                 "service_id": "service-guid-here",
@@ -83,7 +83,7 @@ class BindTest(BrokerTestCase):
             credentials=expected_credentials
         )
 
-        _ = self.client.put(
+        self.client.put(
             "/v2/service_instances/here-instance_id/service_bindings/here-binding_id",
             data=json.dumps({
                 "service_id": "service-guid-here",

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -1,6 +1,13 @@
 import http
 
-from openbrokerapi.catalog import *
+from openbrokerapi.catalog import (
+    Service,
+    ServiceDashboardClient,
+    ServiceMetadata,
+    ServicePlan,
+    ServicePlanCost,
+    ServicePlanMetaData,
+)
 from test import BrokerTestCase
 
 

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -96,46 +96,46 @@ class CatalogTest(BrokerTestCase):
 
         self.assertEqual(response.status_code, http.HTTPStatus.OK)
         self.assertEqual(response.json,
-                          dict(
-                              services=[
-                                  dict(id="s1",
-                                          name="service_name",
-                                          description="service_description",
-                                          bindable=True,
-                                          plans=[dict(
-                                              id="p1",
-                                              name="default",
-                                              description="plan_description",
-                                              metadata=dict(
-                                                  displayName="displayName",
-                                                  bullets=["bullet1"],
-                                                  costs=[dict(
-                                                      amount={"requests": 1},
-                                                      unit="unit"
-                                                  )]
-                                              ),
-                                              free=True,
-                                              bindable=True
-                                          )],
-                                          tags=['tag1', 'tag2'],
-                                          requires=['something'],
+                         dict(
+                             services=[
+                                 dict(id="s1",
+                                      name="service_name",
+                                      description="service_description",
+                                      bindable=True,
+                                      plans=[dict(
+                                          id="p1",
+                                          name="default",
+                                          description="plan_description",
                                           metadata=dict(
                                               displayName="displayName",
-                                              imageUrl="imageUrl",
-                                              longDescription="longDescription",
-                                              providerDisplayName="providerDisplayName",
-                                              documentationUrl="documentationUrl",
-                                              supportUrl="supportUrl"
+                                              bullets=["bullet1"],
+                                              costs=[dict(
+                                                  amount={"requests": 1},
+                                                  unit="unit"
+                                              )]
                                           ),
-                                          dashboard_client=dict(
-                                              id="id",
-                                              secret="secret",
-                                              redirect_uri="redirect_uri"
-                                          ),
-                                          plan_updateable=True
-                                          )
-                              ]
-                          ))
+                                          free=True,
+                                          bindable=True
+                                      )],
+                                      tags=['tag1', 'tag2'],
+                                      requires=['something'],
+                                      metadata=dict(
+                                          displayName="displayName",
+                                          imageUrl="imageUrl",
+                                          longDescription="longDescription",
+                                          providerDisplayName="providerDisplayName",
+                                          documentationUrl="documentationUrl",
+                                          supportUrl="supportUrl"
+                                      ),
+                                      dashboard_client=dict(
+                                          id="id",
+                                          secret="secret",
+                                          redirect_uri="redirect_uri"
+                                      ),
+                                      plan_updateable=True
+                                      )
+                             ]
+                         ))
 
     def test_catalog_returns_200_with_minimal_service_information(self):
         self.broker.catalog.return_value = self.service_list
@@ -150,18 +150,18 @@ class CatalogTest(BrokerTestCase):
 
         self.assertEqual(response.status_code, http.HTTPStatus.OK)
         self.assertEqual(response.json,
-                          dict(
-                              services=[
-                                  dict(
-                                      id="s1",
-                                      name="service_name",
-                                      description="service_description",
-                                      bindable=True,
-                                      plan_updateable=False,
-                                      plans=[dict(id="p1", name="default", description="plan_description")]
-                                  )
-                              ]
-                          ))
+                         dict(
+                             services=[
+                                 dict(
+                                     id="s1",
+                                     name="service_name",
+                                     description="service_description",
+                                     bindable=True,
+                                     plan_updateable=False,
+                                     plans=[dict(id="p1", name="default", description="plan_description")]
+                                 )
+                             ]
+                         ))
 
     def test_catalog_returns_500_if_error_raised(self):
         self.broker.catalog.side_effect = Exception("ERROR")
@@ -176,6 +176,6 @@ class CatalogTest(BrokerTestCase):
 
         self.assertEqual(response.status_code, http.HTTPStatus.INTERNAL_SERVER_ERROR)
         self.assertEqual(response.json,
-                          dict(
-                              description="ERROR"
-                          ))
+                         dict(
+                             description="ERROR"
+                         ))

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -24,7 +24,7 @@ class CatalogTest(BrokerTestCase):
     def test_catalog_called_with_the_right_values(self):
         self.broker.catalog.return_value = self.service_list
 
-        _ = self.client.get(
+        self.client.get(
             "/v2/catalog",
             headers={
                 'X-Broker-Api-Version': '2.13',
@@ -36,7 +36,7 @@ class CatalogTest(BrokerTestCase):
     def test_catalog_ignores_request_headers(self):
         self.broker.catalog.return_value = self.service_list
 
-        _ = self.client.get(
+        self.client.get(
             "/v2/catalog",
             headers={
                 'X-Broker-Api-Version': '2.13',
@@ -47,7 +47,7 @@ class CatalogTest(BrokerTestCase):
         self.assertTrue(self.broker.catalog.called)
 
     def test_catalog_returns_200_with_service_information(self):
-        self.broker.catalog.return_value = service_list = [
+        self.broker.catalog.return_value = [
             Service(id="s1",
                     name="service_name",
                     description="service_description",

--- a/test/test_deprovisioning.py
+++ b/test/test_deprovisioning.py
@@ -10,7 +10,7 @@ class DeprovisioningTest(BrokerTestCase):
     def test_deprovisioning_is_called_with_the_right_values(self):
         self.broker.deprovision.return_value = DeprovisionServiceSpec(False, "operation_str")
 
-        _ = self.client.delete(
+        self.client.delete(
             "/v2/service_instances/here_instance_id?service_id=service-id-here&plan_id=plan-id-here&accepts_incomplete=true",
             headers={
                 'X-Broker-Api-Version': '2.13',
@@ -28,7 +28,7 @@ class DeprovisioningTest(BrokerTestCase):
     def test_deprovisioning_called_just_with_required_fields(self):
         self.broker.deprovision.return_value = DeprovisionServiceSpec(False, "operation_str")
 
-        _ = self.client.delete(
+        self.client.delete(
             "/v2/service_instances/here_instance_id?service_id=service-id-here&plan_id=plan-id-here",
             headers={
                 'X-Broker-Api-Version': '2.13',

--- a/test/test_last_operation.py
+++ b/test/test_last_operation.py
@@ -9,7 +9,7 @@ class LastOperationTest(BrokerTestCase):
     def test_last_operation_called_just_with_required_fields(self):
         self.broker.last_operation.return_value = LastOperation(OperationState.IN_PROGRESS, "Running...")
 
-        _ = self.client.get(
+        self.client.get(
             "/v2/service_instances/here-instance_id/last_operation",
             headers={
                 'X-Broker-Api-Version': '2.13',
@@ -22,7 +22,7 @@ class LastOperationTest(BrokerTestCase):
         self.broker.last_operation.return_value = LastOperation(OperationState.IN_PROGRESS, "Running...")
 
         query = "service_id=123&plan_id=456&operation=operation-data"
-        _ = self.client.get(
+        self.client.get(
             "/v2/service_instances/here-instance_id/last_operation?%s" % query,
             headers={
                 'X-Broker-Api-Version': '2.13',

--- a/test/test_last_operation.py
+++ b/test/test_last_operation.py
@@ -31,8 +31,6 @@ class LastOperationTest(BrokerTestCase):
 
         self.broker.last_operation.assert_called_once_with("here-instance_id", "operation-data")
 
-
-
     def test_returns_200_with_given_state(self):
         self.broker.last_operation.return_value = LastOperation(OperationState.IN_PROGRESS, "Running...")
 

--- a/test/test_prechecks.py
+++ b/test/test_prechecks.py
@@ -34,7 +34,7 @@ class PrecheckTest(BrokerTestCase):
         self.assertEqual(response.status_code, http.HTTPStatus.BAD_REQUEST)
 
     def test_returns_500_with_json_body_if_exception_was_raised(self):
-        self.broker.deprovision.side_effect=Exception("Boooom!")
+        self.broker.deprovision.side_effect = Exception("Boooom!")
 
         response = self.client.delete(
             "/v2/service_instances/abc?plan_id=a&service_id=b",
@@ -47,7 +47,7 @@ class PrecheckTest(BrokerTestCase):
         self.assertEqual(response.json["description"], "Boooom!")
 
     def test_returns_500_with_json_body_if_service_exception_was_raised(self):
-        self.broker.deprovision.side_effect=errors.ServiceExeption("Boooom!")
+        self.broker.deprovision.side_effect = errors.ServiceExeption("Boooom!")
 
         response = self.client.delete(
             "/v2/service_instances/abc?plan_id=a&service_id=b",

--- a/test/test_provisioning.py
+++ b/test/test_provisioning.py
@@ -10,7 +10,7 @@ class ProvisioningTest(BrokerTestCase):
     def test_provisining_called_with_the_right_values(self):
         self.broker.provision.return_value = ProvisionedServiceSpec(dashboard_url="dash_url", operation="operation_str")
 
-        _ = self.client.put(
+        self.client.put(
             "/v2/service_instances/here-instance-id?accepts_incomplete=true",
             data=json.dumps({
                 "service_id": "service-guid-here",
@@ -40,7 +40,7 @@ class ProvisioningTest(BrokerTestCase):
     def test_provisining_called_just_with_required_fields(self):
         self.broker.provision.return_value = ProvisionedServiceSpec(dashboard_url="dash_url", operation="operation_str")
 
-        _ = self.client.put(
+        self.client.put(
             "/v2/service_instances/here-instance-id",
             data=json.dumps({
                 "service_id": "service-guid-here",
@@ -68,7 +68,7 @@ class ProvisioningTest(BrokerTestCase):
     def test_provisining_ignores_unknown_parameters(self):
         self.broker.provision.return_value = ProvisionedServiceSpec(dashboard_url="dash_url", operation="operation_str")
 
-        _ = self.client.put(
+        self.client.put(
             "/v2/service_instances/here-instance-id",
             data=json.dumps({
                 "service_id": "service-guid-here",

--- a/test/test_serve.py
+++ b/test/test_serve.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 import requests
 
 from openbrokerapi import api
+from openbrokerapi import catalog
 from openbrokerapi import service_broker
 
 
@@ -13,7 +14,7 @@ class ServeTest(TestCase):
     def test_serve_starts_server(self):
         def run_server():
             class TestBroker(service_broker.ServiceBroker):
-                def catalog(self) -> List[api.Service]:
+                def catalog(self) -> List[catalog.Service]:
                     return []
 
             api.serve(TestBroker(), api.BrokerCredentials("", ""))

--- a/test/test_unbind.py
+++ b/test/test_unbind.py
@@ -11,7 +11,7 @@ class UnbindTest(BrokerTestCase):
         self.broker.unbind.return_value = None
 
         query = "service_id=service-id-here&plan_id=plan-id-here"
-        _ = self.client.delete(
+        self.client.delete(
             "/v2/service_instances/here_instance_id/service_bindings/here_binding_id?%s" % query,
             headers={
                 'X-Broker-Api-Version': '2.13',

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -10,7 +10,7 @@ class UpdateTest(BrokerTestCase):
     def test_update_called_with_the_right_values(self):
         self.broker.update.return_value = UpdateServiceSpec(False, "operation")
 
-        _ = self.client.patch(
+        self.client.patch(
             "/v2/service_instances/here-service-instance-id?accepts_incomplete=true",
             data=json.dumps({
                 "service_id": "service-guid-here",
@@ -47,7 +47,7 @@ class UpdateTest(BrokerTestCase):
     def test_update_called_called_just_with_required_fields(self):
         self.broker.update.return_value = UpdateServiceSpec(False, "operation")
 
-        _ = self.client.patch(
+        self.client.patch(
             "/v2/service_instances/here-service-instance-id",
             data=json.dumps({
                 "service_id": "service-guid-here",
@@ -71,7 +71,7 @@ class UpdateTest(BrokerTestCase):
     def test_update_ignores_unknown_parameters(self):
         self.broker.update.return_value = UpdateServiceSpec(False, "operation")
 
-        _ = self.client.patch(
+        self.client.patch(
             "/v2/service_instances/here-service-instance-id?accepts_incomplete=true",
             data=json.dumps({
                 "service_id": "service-guid-here",


### PR DESCRIPTION
Removed all wildcard imports, this is discouraged by pep8.

Also flake8 showed multiple whitespace errors.

Flake8 still complains about unused `_` variables in the tests. Ok to remove? If so I will add another commit.