### PR TITLE
permit to run a broker without authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,9 @@ Usage
     # Simpely start the server
     serve(CustomServiceBroker(), BrokerCredentials("", ""))
 
+    # or start the server without authentication
+    serve(CustomServiceBroker(), None)
+
     # or register blueprint to your own FlaskApp instance
     app = Flask(__name__)
     logger = basic_config() #  Use root logger with a basic configuration provided by openbrokerapi.log_utils

--- a/openbrokerapi/api.py
+++ b/openbrokerapi/api.py
@@ -78,7 +78,7 @@ def get_blueprint(service_broker: ServiceBroker,
         @wraps(f)
         def decorated(*args, **kwargs):
             auth = request.authorization
-            if not auth or not check_auth(auth.username, auth.password):
+            if broker_credentials is not None and ( not auth or not check_auth(auth.username, auth.password) ):
                 return authenticate()
             return f(*args, **kwargs)
 

--- a/openbrokerapi/api.py
+++ b/openbrokerapi/api.py
@@ -78,7 +78,7 @@ def get_blueprint(service_broker: ServiceBroker,
         @wraps(f)
         def decorated(*args, **kwargs):
             auth = request.authorization
-            if broker_credentials is not None and ( not auth or not check_auth(auth.username, auth.password) ):
+            if broker_credentials and ( not auth or not check_auth(auth.username, auth.password) ):
                 return authenticate()
             return f(*args, **kwargs)
 

--- a/test/test_serve.py
+++ b/test/test_serve.py
@@ -32,3 +32,24 @@ class ServeTest(TestCase):
 
         server.terminate()
         server.join()
+
+    def test_serve_starts_server_without_auth(self):
+        def run_server():
+            class TestBroker(service_broker.ServiceBroker):
+                def catalog(self) -> List[catalog.Service]:
+                    return []
+
+            api.serve(TestBroker(), None)
+
+        server = Process(target=run_server)
+        server.start()
+
+        time.sleep(2)
+        response = requests.get("http://localhost:5000/v2/catalog",
+                                headers={'X-Broker-Api-Version': '2.13'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), dict(services=[]))
+
+        server.terminate()
+        server.join()


### PR DESCRIPTION
This patch permit to start the broker without authentication if needed.

To don't change the global structure of the code, a None arg can be passed instead of a BrokerCredentials() to the serve function.

If the broker_credential is None, the auth will be bypassed.

The unittest is added to cover this new state.

thanks