### PR TITLE
plan_id is an optional field in service instance update action

### DIFF
--- a/openbrokerapi/api.py
+++ b/openbrokerapi/api.py
@@ -170,7 +170,8 @@ def get_blueprint(service_brokers: Union[List[ServiceBroker], ServiceBroker],
             update_details.originating_identity = request.originating_identity
             update_details.authorization_username = extract_authorization_username(request)
             broker = get_broker_by_id(update_details.service_id)
-            if not broker.check_plan_id(update_details.plan_id):
+            plan_id = update_details.plan_id
+            if plan_id and not broker.check_plan_id(plan_id):
                 raise TypeError('plan_id not found in this service.')
         except (TypeError, KeyError, JSONDecodeError) as e:
             logger.exception(e)


### PR DESCRIPTION
There's a slight mismatch between implementation and specification. The `plan_id` field is optional during an update. With this change the openbroker api can properly support plans with `plan_updateable=False`.

See:
https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#updating-a-service-instance