### PR TITLE
Fix collections.abc deprecation

### DIFF
--- a/openbrokerapi/helper.py
+++ b/openbrokerapi/helper.py
@@ -24,7 +24,7 @@ def version_tuple(v):
 
 def ensure_list(x: Union[Iterable, Any]):
     import collections
-    if isinstance(x, collections.Iterable):
+    if isinstance(x, collections.abc.Iterable):
         return x
     else:
         return [x]


### PR DESCRIPTION
`collections.Iterable` was moved to `collections.abc.Iterable` in python 3.3. This updates the reference to squash the deprecation warning