### PR TITLE
fixing HTTP codes for some exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =============
 
+  - ErrConcurrentInstanceAccess exception on an instance update, an instance deprovision, a binding or unbinding must return 422 not 500.
+  - ErrPlanChangeNotSupported exception must return 400 not 500.
+
+
 **v4.1**
   - Drop Python 3.5 support
   - Fix ´bind´ in multi broker setup (#117); thx @vaxvms

--- a/openbrokerapi/api.py
+++ b/openbrokerapi/api.py
@@ -197,6 +197,10 @@ def get_blueprint(service_broker: ServiceBroker,
                 error="AsyncRequired",
                 description="This service plan requires client support for asynchronous service operations."
             )), HTTPStatus.UNPROCESSABLE_ENTITY
+        except errors.ErrConcurrentInstanceAccess:
+            error_response = ErrorResponse(error='ConcurrencyError',
+                                           description='The Service Broker does not support concurrent requests that mutate the same resource.')
+            return to_json_response(error_response), HTTPStatus.UNPROCESSABLE_ENTITY
 
         if result.is_async:
             return to_json_response(UpdateResponse(result.operation, result.dashboard_url)), HTTPStatus.ACCEPTED
@@ -229,6 +233,10 @@ def get_blueprint(service_broker: ServiceBroker,
                 error="RequiresApp",
                 description="This service supports generation of credentials through binding an application only."
             )), HTTPStatus.UNPROCESSABLE_ENTITY
+        except errors.ErrConcurrentInstanceAccess:
+            error_response = ErrorResponse(error='ConcurrencyError',
+                                           description='The Service Broker does not support concurrent requests that mutate the same resource.')
+            return to_json_response(error_response), HTTPStatus.UNPROCESSABLE_ENTITY
 
         response = BindResponse(
             credentials=result.credentials,
@@ -267,6 +275,10 @@ def get_blueprint(service_broker: ServiceBroker,
         except errors.ErrBindingDoesNotExist as e:
             logger.exception(e)
             return to_json_response(EmptyResponse()), HTTPStatus.GONE
+        except errors.ErrConcurrentInstanceAccess:
+            error_response = ErrorResponse(error='ConcurrencyError',
+                                           description='The Service Broker does not support concurrent requests that mutate the same resource.')
+            return to_json_response(error_response), HTTPStatus.UNPROCESSABLE_ENTITY
 
         if result.is_async:
             return to_json_response(UnbindResponse(result.operation)), HTTPStatus.ACCEPTED
@@ -300,6 +312,10 @@ def get_blueprint(service_broker: ServiceBroker,
                 error="AsyncRequired",
                 description="This service plan requires client support for asynchronous service operations."
             )), HTTPStatus.UNPROCESSABLE_ENTITY
+        except errors.ErrConcurrentInstanceAccess:
+            error_response = ErrorResponse(error='ConcurrencyError',
+                                           description='The Service Broker does not support concurrent requests that mutate the same resource.')
+            return to_json_response(error_response), HTTPStatus.UNPROCESSABLE_ENTITY
 
         if result.is_async:
             return to_json_response(DeprovisionResponse(result.operation)), HTTPStatus.ACCEPTED

--- a/openbrokerapi/errors.py
+++ b/openbrokerapi/errors.py
@@ -47,7 +47,7 @@ class ErrAsyncRequired(ServiceException):
         super().__init__("This service plan requires client support for asynchronous service operations.")
 
 
-class ErrPlanChangeNotSupported(ServiceException):
+class ErrPlanChangeNotSupported(ErrInvalidParameters):
     def __init__(self):
         super().__init__("The requested plan migration cannot be performed")
 


### PR DESCRIPTION
- **ErrConcurrentInstanceAccess** exception on an instance update, an instance deprovision, a binding or unbinding must return **422** not 500.
- **ErrPlanChangeNotSupported** exception must return **400** not 500.